### PR TITLE
Fix branch cleanup script condition

### DIFF
--- a/utilities/git-branches-clean-up.js
+++ b/utilities/git-branches-clean-up.js
@@ -29,9 +29,12 @@ const branches = execCommand("git branch --merged main")
   );
 
 // Delete each branch safely
+// Main branches that should never be removed
+const protectedBranches = ["main", "master"];
+
 branches.forEach((branch) => {
-  if (branch !== "main" && branch !== "main") {
-    // Replace with your main branch names if different
+  // Replace with your main branch names if different
+  if (!protectedBranches.includes(branch)) {
     try {
       execSync(`git branch -d ${branch}`, { stdio: "inherit" });
     } catch (error) {


### PR DESCRIPTION
## Summary
- update condition in git-branches-clean-up.js to avoid deleting main/master

## Testing
- `npm test` *(fails: Missing script)*
- `npx prettier utilities/git-branches-clean-up.js --write` *(fails: cannot find plugin)*

------
https://chatgpt.com/codex/tasks/task_e_683f8666ea7c832e891b7c4d41786d44